### PR TITLE
Asciidoc conversion

### DIFF
--- a/adoc-convert-md.sh
+++ b/adoc-convert-md.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Simple script to convert asciidoc format King James Bible into basic markdown format
+# These files can subsequently processed by the md-beautify-pdf.sh script to create
+# a more traditional looking bible layout PDF (two column, drop caps, headers/footers, etc)
+# Usage: adoc-convert-md.sh [-c] book.asciidoc
+
+# Process script options
+CLEANUP=true
+while getopts ":c" opt; do
+  case ${opt} in
+    c ) # Don't cleanup all generated files (default is true)
+			CLEANUP=false
+      ;;
+    \? ) echo "Usage: adoc-convert-md.sh [-c] book.asciidoc"
+      ;;
+  esac
+done
+
+# Input file, usually "book.asciidoc"
+shift $(( OPTIND - 1 ))
+inputfile=$1
+
+# Create temp file
+cp $inputfile ${inputfile}.$$
+
+# Strip chapter navigation tables as they get mutiliated by markdown conversion
+# TODO: Is there a asciidoc equivalent of 'minitoc'? It would make the original generation of
+#       these bible book level navigation tables so much easier.
+perl -i -p0e 's/(^== (?!Copyright\v)(\p{PosixPrint}+\v)).*?(^=== \p{PosixPrint}+ Chapter 1\v)/\1\n\n\3/gms' ${inputfile}.$$
+
+# Split into Old and New Testament markdown files as Markdown does not support multiple
+# "titles" like asciidoc
+perl -ne 'print if (/= The Old Testament/ .. /= The New Testament/)' ${inputfile}.$$ > TheOldTestament.$$
+perl -ne 'print if (/= The New Testament/ .. eof)' ${inputfile}.$$ > TheNewTestament.$$
+
+# Strip title level section headings
+perl -i -pe 's/(^= \p{PosixPrint}+\v)//g' TheOldTestament.$$ TheNewTestament.$$
+
+# Convert each testament to XML DocBook format
+echo "Converting Old Testament to DocBook format"
+asciidoc -b docbook -o TheOldTestament.xml.$$ TheOldTestament.$$
+echo "Converting New Testament to DocBook format"
+asciidoc -b docbook -o TheNewTestament.xml.$$ TheNewTestament.$$
+
+# Do final conversion to Markdown format
+# +RTS -K100000000 -RTS increase pandoc stack size to avoid errors
+echo "Converting Old Testament to Markdown format"
+#pandoc +RTS -K100000000 -RTS -f docbook -t markdown_strict TheOldTestament.xml.$$ TheOldTestament.$$ -o TheOldTestament.md
+pandoc +RTS -K100000000 -RTS -f docbook -t markdown_strict TheOldTestament.xml.$$ -o TheOldTestament.md
+echo "Converting New Testament to Markdown format"
+#pandoc +RTS -K100000000 -RTS -f docbook -t markdown_strict TheNewTestament.xml.$$ TheNewTestament.$$ -o TheNewTestament.md
+pandoc +RTS -K100000000 -RTS -f docbook -t markdown_strict TheNewTestament.xml.$$ -o TheNewTestament.md
+
+## TODO
+# Convert or parse metadata.yaml to md-metadata-pdf.yaml on the fly
+
+# Clean up
+if [ "$CLEANUP" == true ]; then
+  rm TheOldTestament.xml.$$ TheOldTestament.$$ TheNewTestament.xml.$$ TheNewTestament.$$ ${inputfile}.$$
+fi

--- a/md-beautify-pdf.sh
+++ b/md-beautify-pdf.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Simple script to add latex hinting to markdown for fancy PDF generation using pandoc
+# Uses the two markdown books output from the adoc-convert-md.sh script to create a latex
+# hinted markdown file suitable for conversion to PDF
+# Usage: md-beautify-pdf.sh [-p] [-c] TheOldTestament.md TheNewTestament.md
+
+# Process script options
+GENERATE_PDF=false
+CLEANUP=true
+while getopts ":pc" opt; do
+  case ${opt} in
+    p ) # Generate PDF with pandoc
+			GENERATE_PDF=true
+      ;;
+    c ) # Don't cleanup all generated files (default is true)
+			CLEANUP=false
+      ;;
+    \? ) echo "Usage: md-beautify-pdf.sh [-p] [-c] TheOldTestament.md TheNewTestament.md"
+      ;;
+  esac
+done
+
+# Source markdown files
+shift $(( OPTIND - 1 ))
+oldtestament=$1
+newtestament=$2
+
+# Intermediate markdown with Latex formatting
+bible=TheKingJamesBible.md
+
+# Add Old/New Testament parts
+echo -e '\\tableofcontents\n\n\\part{The Old Testament}\n' >> ${oldtestament}.$$ 
+echo -e '\\part{The New Testament}\n' >> ${newtestament}.$$ 
+echo -e '\\addtocontents{toc}{\\protect\\mbox{}\\protect\\hrulefill\\par}\n\\addtocontents{toc}{\\protect\\begin{multicols}{2}}\n' | tee -a ${oldtestament}.$$ ${newtestament}.$$ >/dev/null
+
+# Add content
+cat $oldtestament >> ${oldtestament}.$$
+cat $newtestament >> ${newtestament}.$$
+
+# Close part columns
+echo -e '\\End{multicols}\n\\addtocontents{toc}{\\protect\\end{multicols}}' | tee -a ${oldtestament}.$$ ${newtestament}.$$ >/dev/null
+
+# Merge parts
+cat ${oldtestament}.$$ ${newtestament}.$$ > $bible
+
+# Add "inner" column definition
+perl -i -p0e 's/(^\p{PosixPrint}+\v={2,}\v\s+?)/\1\\Begin\{multicols\}\{2\}\n\n/gms' $bible
+perl -i -p0e 's/(^\p{PosixPrint}+\v={2,}\v\s+?)/\\End\{multicols\}\n\n\1/gms' $bible
+
+# Nuke stray multicol tag, this is hacky but I gave up on the lookbehind regex :)
+perl -i -p0e 's/(\}\s+)\\End\{multicols\}/\1/gms' $bible
+
+# Add "lettrine" drop caps to first word of first paragraph in each chapter
+perl -i -pe 's/^\d+:1\s+(\w)(\w*)\b/`\\lettrine\{\1\}\{\2\}`\{=latex\}/g' $bible
+
+# Adjust chapter headings
+perl -i -p0e 's/^(\p{PosixPrint}+)\v={2,}/\\chapter\{\1\}/gms' $bible
+
+# Adjust section headings
+perl -i -p0e 's/^(\p{PosixPrint}+)\s(Chapter\s\d+)\v\-{2,}/\\section\{\\uppercase\{\2\}\}\\label\{\1 \2\}/gms' $bible
+
+# Generate PDF
+# Note the use of the lualatex engine for PDF generation. The xelatex engine
+# encounters memory issues due to the massive size of the book.
+if [ "$GENERATE_PDF" = true ]; then
+  pandoc -s TheKingJamesBible.md md-metadata-pdf.yaml --pdf-engine=lualatex -o TheKingJamesBible.pdf
+fi
+
+## Clean up
+if [ "$CLEANUP" == true ]; then
+	rm ${oldtestament}.$$ ${newtestament}.$$ TheKingJamesBible.md 
+fi

--- a/md-metadata-pdf.yaml
+++ b/md-metadata-pdf.yaml
@@ -1,0 +1,51 @@
+---
+title: The King James Bible
+author: Various
+papersize: letter
+## Enable the QTCloisteredMonk font for a cool medieval look :)
+#mainfont: QTCloisteredMonk.otf
+#sansfont: QTCloisteredMonk.otf
+fontsize: 10pt
+geometry: left=4cm,right=4cm,top=3cm,bottom=3cm
+header-includes:
+    ## Various Latex package imports
+    - \usepackage{multicol}  # Multiple column support
+    - \usepackage{lettrine}  # Easy way to make basic "drop caps" for chapter first paragraphs.
+    - \usepackage{bookmark}  # Allows fine control of bookmarks
+    - \usepackage{sectsty}   # Allows greater control of section styling
+    - \usepackage{fancyhdr}  # Easy and good looking headers/footers
+    ## Retain full depth navigation in heirarchical bookmarks
+    - \bookmarksetup{depth=1}
+    ## Remove all section numbering (prefixes)
+    - \setcounter{secnumdepth}{-2}
+    ## Limit depth to just part and chapter for TOC display
+    - \setcounter{tocdepth}{0}
+    ## Configure fancyhdr package
+    - \pagestyle{fancy}
+    - \fancyhf{}
+    - \lhead{\leftmark}
+    - \rhead{\rightmark}
+    - \cfoot{\thepage}
+    ## Tweak the appearance of chapter and section headings
+    - \chapterfont{\bf\centering}
+    - \sectionfont{\bf\centering\selectfont}
+    ## Configure lettrine "drop cap" line height
+    - \setcounter{DefaultLines}{2}
+    ## Configure column separator whitespace width and separator line
+    - \setlength{\columnseprule}{0.4pt}
+    - \setlength{\columnsep}{.5cm}
+    ## Hack to keep pandoc from barfing on "\begin" and "\end" tags needed
+    ## for multicol configuration
+    - \newcommand{\hideFromPandoc}[1]{#1}
+    - \hideFromPandoc{
+        \let\Begin\begin
+        \let\End\end
+      }
+documentclass: book
+classoption:
+    ## Suitable config for screen reading PDF
+    - openany
+    ## Uncomment "oneside" for a more natural book style, useful if PDF is going to be
+    ## printed on paper and made into a physical book.
+    # - oneside
+...

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 _repo: The-King-James-Bible_10900
-_version: 0.1.0
+_version: 0.1.1
 covers:
 - cover_type: generated
   image_path: cover.png


### PR DESCRIPTION
Hello,

This is my second try at this pull request. I missed some of the asciidoc conversion steps the first time around.

So here's my attempt at an asciidoc conversion for this book. I have tested building a PDF and epub locally and they both built cleanly with asciidoctor-pdf and asciidoctor-epub3 from the book.asciidoc file. The output files appeared clean and links worked properly. I'm not sure if they will build successfully with the automated build pipeline, but I hope they will.

I used the 10900-8.txt file as the source for my conversion and I stripped out most of the old licensing text. I'm not sure if this is the right thing to do, please let me know if there is a more detailed template that I should be following for asciidoc conversion. If you notice any corrections that need to be made, please let me know.

I have also created a couple of scripts and metadata which translate the asciidoc format to a PDF (via pandoc) with a more typical print layout. It is similar to what you would see in published King James Version bibles (two column layout, drop caps, reduced depth table of contents, etc). I think the format looks pretty good, but it could certainly use a lot of tweaking and improvement. See the following for a sample:
[TheKingJamesBible.pdf](https://github.com/GITenberg/The-King-James-Bible_10900/files/5768496/TheKingJamesBible.pdf)

I'm not sure if this repo is an appropriate place for the helper scripts and metadata. Please let me know if you have preferences on where tools like this should be tracked. They are very specific to this particular book, so there should be some kind of link. I welcome your feedback!

Thanks for having this awesome project available on Github!

Cheers,

Sam